### PR TITLE
unused-index-list-improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ pgindexinsight [command] [options]
 ## Examples
 
 ```bash
-pgindexinsight list-unused-or-old-indexes --json --output-path '/where/to/put/json/'
+pgindexinsight list-unused-indexes --json --output-path '/where/to/put/json/'
 pgindexinsight list-invalid-indexes --json --output-path '/where/to/put/json/' --dry-run
 pgindexinsight list-bloated-btree-indexes --json --output-path '/where/to/put/json/' --dry-run --bloat-threshold 5
 pgindexinsight list-unemployed-indexes --json --output-path '/where/to/put/json/' --dry-run
@@ -107,7 +107,7 @@ pgindexinsight list-unemployed-indexes --json --output-path '/where/to/put/json/
 
 ### Available Commands
 
-- `list-unused-or-old-indexes`: Lists unused or outdated indexes.
+- `list-unused-indexes`: Lists unused or outdated indexes.
     - Options:
         - --json: Export output to a JSON file.
         - --output-path: JSON file output directory.

--- a/pg_index_insight/cli.py
+++ b/pg_index_insight/cli.py
@@ -9,7 +9,7 @@ from .database import DatabaseManager as DatabaseManager
 @click.command()
 @click.option("--json", is_flag=True, help="Export output to JSON file.")
 @click.option("--output-path", type=str,default='/tmp/',show_default=True,help="Output file directory")
-def list_unused_or_old_indexes(json,output_path):
+def list_unused_indexes(json,output_path):
     """
     Connects to the PostgreSQL database and retrieves unused or redundant indexes. 
     This function queries the database for indexes that are not frequently scanned 
@@ -304,7 +304,7 @@ def main():
 main.add_command(list_bloated_btree_indexes)
 main.add_command(list_unemployed_indexes)
 main.add_command(list_invalid_indexes)
-main.add_command(list_unused_or_old_indexes)
+main.add_command(list_unused_indexes)
 
 if __name__ == '__main__':
     main()

--- a/pg_index_insight/cli.py
+++ b/pg_index_insight/cli.py
@@ -175,7 +175,7 @@ def list_unemployed_indexes(json,dry_run,output_path):
             click.echo(f'No inefficient index found for database: {database_name}')
             exit(0)
         table_formatted_index_result = [
-            [item["database_name"], item["schema_name"],item["index_name"],item["index_size"], item["category"]]
+            [item["database_name"], item["schema_name"],item["index_name"],item["index_size"], item["category"],database_query.replica_node_exists,database_query.recovery_status]
             for item in indexResult
         ]
         # append duplicate unique indexes
@@ -185,7 +185,9 @@ def list_unemployed_indexes(json,dry_run,output_path):
                 unique_index[0],
                 unique_index[2],
                 unique_index[4],
-                "Duplicate Unique Index"
+                "Duplicate Unique Index",
+                database_query.replica_node_exists,
+                database_query.recovery_status
             ])
 
         # append duplicate btree indexes
@@ -195,9 +197,11 @@ def list_unemployed_indexes(json,dry_run,output_path):
                 btree_index[0],
                 btree_index[2],
                 btree_index[4],
-                "Duplicate Btree Index"
+                "Duplicate Btree Index",
+                database_query.replica_node_exists,
+                database_query.recovery_status
             ])
-        index_table_headers = ["Database Name","Schema Name", "Index Name","Index Size", "Category"]
+        index_table_headers = ["Database Name","Schema Name", "Index Name","Index Size", "Category","Physical Replication Exists","Database Recovery Enabled"]
         report_time = str.replace(str(time.time()), ".", "_")
         json_report_name=f'''{database_name}_inefficient_index_{report_time}'''
         sorted_desc_index_list = sorted(table_formatted_index_result, key=lambda x: x[3],reverse=True)
@@ -251,10 +255,10 @@ def list_bloated_btree_indexes(json,dry_run,bloat_threshold,output_path):
             click.echo(f'No bloated index found for database: {database_name}')
             exit(0)
         table_formatted_index_result = [
-            [item["database_name"],item["schema_name"], item["index_name"],item["bloat_ratio"],item["category"]]
+            [item["database_name"],item["schema_name"], item["index_name"],item["bloat_ratio"],item["category"],databaseConnection.replica_node_exists,databaseConnection.recovery_status]
             for item in indexResult
         ]
-        index_table_headers = ["Database Name","Schema Name","Index Name","Bloat Ratio", "Category"]
+        index_table_headers = ["Database Name","Schema Name","Index Name","Bloat Ratio", "Category","Physical Replication Exists","Database Recovery Enabled"]
         report_time = str.replace(str(time.time()), ".", "_")
         json_report_name=f'''{database_name}_bloated_index_{report_time}'''
         index_result_table = tabulate(

--- a/pg_index_insight/cli.py
+++ b/pg_index_insight/cli.py
@@ -48,8 +48,8 @@ def list_unused_indexes(json,output_path):
             "Index Name",
             "Index Size",
             "Category",
-            "Replica Node Exists",
-            "Database Recovery Mode"
+            "Physical Replication Exists",
+            "Database Recovery Enabled"
         ]
         index_result_table = tabulate(
             table_formatted_index_result, index_table_headers, tablefmt="psql"

--- a/pg_index_insight/cli.py
+++ b/pg_index_insight/cli.py
@@ -37,7 +37,6 @@ def list_unused_or_old_indexes(json,output_path):
                 item["index_name"],
                 item["index_size"],
                 item["index_scan"],
-                item["last_scan"],
                 item["category"],
                 database_instance.replica_node_exists,
                 database_instance.recovery_status,
@@ -50,7 +49,6 @@ def list_unused_or_old_indexes(json,output_path):
             "Index Name",
             "Index Size",
             "Index Scan Count",
-            "Last Scan Date",
             "Category",
             "Replica Node Exists",
             "Database Recovery Mode"
@@ -128,7 +126,7 @@ def list_invalid_indexes(dry_run,json,drop_force,output_path):
                 except Exception as e:
                     click.echo(f"Failed to export json, error: {str(e)} ")  
             if dry_run:
-                click.echo(f'''The following queries might be run on database: {database_name} to remove invalid indexes. Please run the commands wisely.''')
+                click.echo(f'''The following queries might be run on database: {database_name} to remove invalid indexes. Please run the following commands wisely.''')
                 drop_force=False
                 for index in invalid_indexes:
                     command_executed=generate_command(index['category'],index['schema_name'],index['index_name'])
@@ -217,7 +215,7 @@ def list_unemployed_indexes(json,dry_run,output_path):
             except Exception as e:
                 click.echo(f"Failed to export json, error: {str(e)} ")
         if dry_run:
-            click.echo(f'''The following queries might be run on database: {database_name}. Please run the commands wisely.''')
+            click.echo(f'''The following queries might be run on database: {database_name}. Please run the following commands wisely.''')
             for index in sorted_desc_index_list:
                 command_executed=generate_command(index[0],index[1],index[2])
                 click.echo(command_executed)
@@ -274,7 +272,7 @@ def list_bloated_btree_indexes(json,dry_run,bloat_threshold,output_path):
                 click.echo(f"Failed to export json, Error: {str(e)} ")
 
         if dry_run:
-            click.echo(f'''The following queries might be run on database: {database_name}. Please run the commands wisely.''')
+            click.echo(f'''The following queries might be run on database: {database_name}. Please run the following commands wisely.''')
             for index in indexResult:
                 command_executed=generate_command(index['category'],index['schema_name'],index['index_name'])
                 click.echo(command_executed)

--- a/pg_index_insight/cli.py
+++ b/pg_index_insight/cli.py
@@ -288,7 +288,7 @@ def main():
     inefficient, invalid, unused, or bloated indexes. 
 
     Available commands include:
-    - list_unused_or_old_indexes: Lists indexes that are no longer in use.
+    - list_unused_indexes: Lists indexes that are no longer in use.
     - list_invalid_indexes: Identifies indexes that are misconfigured or corrupted.
     - list_duplicate_indexes: Finds duplicate B-tree indexes.
     - list_unemployed_indexes: Reports on indexes that are underperforming.

--- a/pg_index_insight/cli.py
+++ b/pg_index_insight/cli.py
@@ -102,6 +102,9 @@ def list_invalid_indexes(dry_run,json,drop_force,output_path):
                     item["index_name"],
                     item["index_size"],
                     item["category"],
+                    database_query.replica_node_exists,
+                    database_query.recovery_status,
+                    
                 ]
                 for item in invalid_indexes
             ]
@@ -111,6 +114,8 @@ def list_invalid_indexes(dry_run,json,drop_force,output_path):
                 "Index Name",
                 "Index Size",
                 "Category",
+                "Physical Replication Exists",
+                "Database Recovery Enabled"
             ]
             index_result_table = tabulate(
                 table_formatted_index_result, index_table_headers, tablefmt="psql"

--- a/pg_index_insight/cli.py
+++ b/pg_index_insight/cli.py
@@ -36,7 +36,6 @@ def list_unused_indexes(json,output_path):
                 item["schema_name"],
                 item["index_name"],
                 item["index_size"],
-                item["index_scan"],
                 item["category"],
                 database_instance.replica_node_exists,
                 database_instance.recovery_status,
@@ -48,7 +47,6 @@ def list_unused_indexes(json,output_path):
             "Schema Name",
             "Index Name",
             "Index Size",
-            "Index Scan Count",
             "Category",
             "Replica Node Exists",
             "Database Recovery Mode"

--- a/pg_index_insight/cli.py
+++ b/pg_index_insight/cli.py
@@ -36,9 +36,9 @@ def list_unused_or_old_indexes(json,output_path):
                 item["schema_name"],
                 item["index_name"],
                 item["index_size"],
-                item["category"],                
                 item["index_scan"],
                 item["last_scan"],
+                item["category"],
                 database_instance.replica_node_exists,
                 database_instance.recovery_status,
             ]

--- a/pg_index_insight/database.py
+++ b/pg_index_insight/database.py
@@ -238,7 +238,6 @@ class DatabaseManager:
                     "index_name": index[2],
                     "index_size": index[4],
                     "index_scan": index[3],
-                    "last_scan": index[5],
                     "category": "Redundant&Unused Index",
                 }
                 old_index_list.append(old_index_dict)

--- a/pg_index_insight/database.py
+++ b/pg_index_insight/database.py
@@ -239,7 +239,7 @@ class DatabaseManager:
                     "index_size": index[4],
                     "index_scan": index[3],
                     "last_scan": index[5],
-                    "category": "Unused/Retired Index",
+                    "category": "Redundant&Unused Index",
                 }
                 old_index_list.append(old_index_dict)
         return old_index_list

--- a/pg_index_insight/database.py
+++ b/pg_index_insight/database.py
@@ -238,7 +238,7 @@ class DatabaseManager:
                     "index_name": index[2],
                     "index_size": index[4],
                     "index_scan": index[3],
-                    "category": "Redundant&Unused Index",
+                    "category": "Unused Index",
                 }
                 old_index_list.append(old_index_dict)
         return old_index_list

--- a/pg_index_insight/queries.py
+++ b/pg_index_insight/queries.py
@@ -19,7 +19,6 @@ class SqlQueries:
                 pg_class AS t ON t.oid = idx.indrelid
             WHERE
                 s.idx_scan = 0
-                AND (last_idx_scan IS NULL OR last_idx_scan < NOW() - INTERVAL '1 year')
                 AND NOT idx.indisprimary
                 AND NOT idx.indisunique
         ),
@@ -74,8 +73,7 @@ class SqlQueries:
                 t.relname AS table_name,
                 i.relname AS index_name,
                 idx_scan AS index_scans,
-                pg_size_pretty(pg_relation_size(i.oid)) AS index_size,
-                last_idx_scan AS last_scan_date
+                pg_size_pretty(pg_relation_size(i.oid)) AS index_size
             FROM
                 pg_stat_user_indexes AS s
             JOIN
@@ -86,7 +84,6 @@ class SqlQueries:
                 pg_class AS t ON t.oid = idx.indrelid
             WHERE
                 s.idx_scan=0
-                AND (last_idx_scan IS NULL OR last_idx_scan < NOW() - INTERVAL '1 year')
                 AND NOT idx.indisprimary
                 AND NOT idx.indisunique
             ORDER BY


### PR DESCRIPTION
- change the order of category label to align proper fields at the output 
- change function name from list_unused_or_old_indexes to list_unused_indexes
- update dry run messages to improve readability.
- update unused index category
- remove last_idx_scan field because it might have engender some misleading information 
- remove last_scan column because it is unnecessary to be displayed.
- remove index scan count column from unused index list.
- fix unused index category definition.
- add replication and recovery information to commands to be displayed at output messages.